### PR TITLE
Integrate constants file and clean up function params

### DIFF
--- a/constants.rg
+++ b/constants.rg
@@ -24,7 +24,11 @@ constants.TWO = 2
 constants.FIFTEEN = 15
 constants.vertexDegree = 3
 constants.nVertLevels = 1
+constants.sphere_radius = 6371229.0 --from ncdump of the grid, default is 1.0, but set to "a" from constants.F in init_atm_core.F
+constants.nlat = 721
 
+constants.pii = 3.141592653589793
+constants.omega = 7.29212E-5
 constants.rgas = 287.0
 constants.rv = 461.6
 constants.cp = 7.0*constants.rgas/2.0

--- a/main.rg
+++ b/main.rg
@@ -33,15 +33,15 @@ task main()
   --TODO: This doesn't actually return the halos yet (It creates them in the task but I haven't been able to return them). Need to return the halos.
   partition_regions(constants.NUM_PARTITIONS, cell_region, edge_region, vertex_region)
 
-  init_atm_case_jw(vertex_region, edge_region, cell_region, vertical_region, constants.cp, constants.rgas, constants.gravity)
+  init_atm_case_jw(cell_region, edge_region, vertex_region, vertical_region)
 
-  atm_core_init(cell_region, edge_region, vertex_region, vertical_region, constants.rgas, constants.cp, constants.rvord)
+  atm_core_init(cell_region, edge_region, vertex_region, vertical_region)
 
   --for i = 0, constants.NUM_TIMESTEPS do
-  atm_timestep(1, vertex_region, edge_region, cell_region, vertical_region, constants.config_epssm, constants.rgas, constants.cp, constants.gravity, constants.config_smdiv, constants.config_len_disp)
+  atm_timestep(cell_region, edge_region, vertex_region, vertical_region, 1)
   --end
 
-  atm_compute_output_diagnostics(cell_region, constants.rvord)
+  atm_compute_output_diagnostics(cell_region)
 
   write_output_plotting(cell_region, edge_region, vertex_region)
 

--- a/vertical_init/init_atm_cases.rg
+++ b/vertical_init/init_atm_cases.rg
@@ -1,6 +1,8 @@
 import "regent"
 require "data_structures"
 
+local constants = require("constants")
+
 local nCells = 2562
 local nEdges = 7680
 local nVertices = 5120
@@ -18,18 +20,11 @@ local cmath = terralib.includec("math.h")
 
 
 --__demand(__cuda)
-task init_atm_case_jw(vr : region(ispace(int2d), vertex_fs),
+task init_atm_case_jw(cr : region(ispace(int2d), cell_fs),
                       er : region(ispace(int2d), edge_fs),
-                      cr : region(ispace(int2d), cell_fs),
-                      vertr : region(ispace(int1d), vertical_fs),
-                      cp : double,
-                      rgas : double,
-                      gravity : double)
+                      vr : region(ispace(int2d), vertex_fs),
+                      vertr : region(ispace(int1d), vertical_fs))
 where reads writes(vr, er, cr, vertr) do
--- constants from constants.F --- TODO: combine constants in one place so you don't redefine every time you need
-
-  var pii = 3.141592653589793
-  var omega = 7.29212E-5
 
 -- local vars/constants defined at beginning of subroutine
   var u0 = 35.0
@@ -49,8 +44,8 @@ where reads writes(vr, er, cr, vertr) do
   var pert_radius = 0.1
   var latitude_pert = 40.0
   var longitude_pert = 20.0
-  var theta_c = pii/4.0
-  var lambda_c = 3.0*pii/2.0
+  var theta_c = constants.pii/4.0
+  var lambda_c = 3.0*constants.pii/2.0
   var k_x = 9.0           -- Normal mode wave number
 
 --initialization of moisture:
@@ -128,9 +123,9 @@ where reads writes(vr, er, cr, vertr) do
   var xnutr = 0.0
   var zd = 12000.0
   var znut = eta_t
-  var etavs = (1.0 - 0.252) * pii/2.
+  var etavs = (1.0 - 0.252) * constants.pii/2.
   var r_earth = sphere_radius
-  omega_e = omega
+  omega_e = constants.omega
   var p0 = 1.0E+05
 
 --! We may pass in an hx(:,:) that has been precomputed elsewhere.
@@ -139,7 +134,7 @@ where reads writes(vr, er, cr, vertr) do
   for iCell=0, nCells do
     for k = 0, nz do
       phi = cr[{iCell, 0}].lat
-      cr[{iCell, k}].hx = u0 / gravity * cmath.pow(cmath.cos(etavs), 1.5) * ((-2.0 * cmath.pow(cmath.sin(phi), 6) * (cmath.pow(cmath.cos(phi), 2.0) + 1.0/3.0) + 10.0/63.0) * u0*cmath.pow(cmath.cos(etavs), 1.5) + (1.6 * cmath.pow(cmath.cos(phi), 3) * (cmath.pow(cmath.sin(phi), 2) + 2.0/3.0) - pii/4.0)*r_earth*omega_e)
+      cr[{iCell, k}].hx = u0 / constants.gravity * cmath.pow(cmath.cos(etavs), 1.5) * ((-2.0 * cmath.pow(cmath.sin(phi), 6) * (cmath.pow(cmath.cos(phi), 2.0) + 1.0/3.0) + 10.0/63.0) * u0*cmath.pow(cmath.cos(etavs), 1.5) + (1.6 * cmath.pow(cmath.cos(phi), 3) * (cmath.pow(cmath.sin(phi), 2) + 2.0/3.0) - constants.pii/4.0)*r_earth*omega_e)
     end
   end
 
@@ -188,7 +183,7 @@ where reads writes(vr, er, cr, vertr) do
 --!                ah[k] = 0 is a terrain-following coordinate
 --!                ah[k] = 1 is a height coordinate
 --
-    ah[k] = 1.0 - cmath.pow(cmath.cos(.5*pii*(k-1)*dz/zt), 6.0)
+    ah[k] = 1.0 - cmath.pow(cmath.cos(.5*constants.pii*(k-1)*dz/zt), 6.0)
 --!            ah[k] = 0.
 
     --cio.printf("sh[%d] is %f \n", k, sh[k])
@@ -250,7 +245,7 @@ where reads writes(vr, er, cr, vertr) do
       cr[{i, k}].dss = 0.0
       ztemp = cr[{k,i}].zgrid
       if(ztemp > zd+.1)  then
-         cr[{i, k}].dss = cr[{i, k}].dss+xnutr*cmath.pow(cmath.sin(.5*pii*(ztemp-zd)/(zt-zd)), 2)
+         cr[{i, k}].dss = cr[{i, k}].dss+xnutr*cmath.pow(cmath.sin(.5*constants.pii*(ztemp-zd)/(zt-zd)), 2)
       end
     end
   end
@@ -260,7 +255,7 @@ where reads writes(vr, er, cr, vertr) do
 
 --!**************  section for 2d (z,lat) calc for zonal velocity
 
-  var dlat = 0.5*pii / float(nlat-1)
+  var dlat = 0.5*constants.pii / float(nlat-1)
   var lat_2d : double[nlat]
   var zgrid_2d : double[(nVertLevels + 1) * nlat]
   var zz_2d : double[nVertLevels * nlat]
@@ -286,7 +281,7 @@ where reads writes(vr, er, cr, vertr) do
 
     lat_2d[i] = float(i-1)*dlat
     phi = lat_2d[i]
-    var hx_1d = u0 / gravity * cmath.pow(cmath.cos(etavs),1.5) * ((-2.0 * cmath.pow(cmath.sin(phi), 6) * (cmath.pow(cmath.cos(phi),2)+1.0/3.0)+10.0/63.0) *(u0)*cmath.pow(cmath.cos(etavs),1.5) +(1.6*cmath.pow(cmath.cos(phi),3) *(cmath.pow(cmath.sin(phi),2)+2.0/3.0)-pii/4.0)*r_earth*omega_e)
+    var hx_1d = u0 / constants.gravity * cmath.pow(cmath.cos(etavs),1.5) * ((-2.0 * cmath.pow(cmath.sin(phi), 6) * (cmath.pow(cmath.cos(phi),2)+1.0/3.0)+10.0/63.0) *(u0)*cmath.pow(cmath.cos(etavs),1.5) +(1.6*cmath.pow(cmath.cos(phi),3) *(cmath.pow(cmath.sin(phi),2)+2.0/3.0)-constants.pii/4.0)*r_earth*omega_e)
     for k=0, nz do
       zgrid_2d[k * nlat + i] = (1.-ah[k])*(sh[k]*(zt-hx_1d)+hx_1d) + ah[k] * sh[k]* zt
     end
@@ -296,9 +291,9 @@ where reads writes(vr, er, cr, vertr) do
 
     for k=1,nz1 do
       ztemp = .5*(zgrid_2d[(k+1)*nlat + i]+zgrid_2d[k*nlat + i])
-      ppb_2d[k * nlat + i] = p0*cmath.exp(-gravity*ztemp/(rgas*t0b))
-      pb_2d[k * nlat + i] = cmath.pow((ppb_2d[k * nlat + i]/p0),(rgas/cp))
-      rb_2d[k * nlat + i] = ppb_2d[k * nlat + i]/(rgas*t0b*zz_2d[k * nlat + i])
+      ppb_2d[k * nlat + i] = p0*cmath.exp(-constants.gravity*ztemp/(constants.rgas*t0b))
+      pb_2d[k * nlat + i] = cmath.pow((ppb_2d[k * nlat + i]/p0),(constants.rgas/constants.cp))
+      rb_2d[k * nlat + i] = ppb_2d[k * nlat + i]/(constants.rgas*t0b*zz_2d[k * nlat + i])
       tb_2d[k * nlat + i] = t0b/pb_2d[k * nlat + i]
       rtb_2d[k * nlat + i] = rb_2d[k * nlat + i]*tb_2d[k * nlat + i]
       p_2d[k * nlat + i] = pb_2d[k * nlat + i]
@@ -311,17 +306,17 @@ where reads writes(vr, er, cr, vertr) do
 
       for k=0,nz1 do
         eta[k] = (ppb_2d[k * nlat + i]+pp_2d[k * nlat + i])/p0
-        etav[k] = (eta[k]-.252)*pii/2.0
+        etav[k] = (eta[k]-.252)*constants.pii/2.0
         if(eta[k] >= znut)  then
-          teta[k] = t0*cmath.pow(eta[k],(rgas*dtdz/gravity))
+          teta[k] = t0*cmath.pow(eta[k],(constants.rgas*dtdz/constants.gravity))
         else
-          teta[k] = t0*cmath.pow(eta[k],(rgas*dtdz/gravity)) + delta_t*cmath.pow((znut-eta[k]),5)
+          teta[k] = t0*cmath.pow(eta[k],(constants.rgas*dtdz/constants.gravity)) + delta_t*cmath.pow((znut-eta[k]),5)
         end
       end
 
       phi = lat_2d[i]
       for k=1,nz1 do
-        temperature_1d[k] = teta[k]+.75*eta[k]*pii*u0/rgas*cmath.sin(etav[k])  *cmath.sqrt(cmath.cos(etav[k]))* ((-2.*cmath.pow(cmath.sin(phi),6)  *(cmath.pow(cmath.cos(phi),2)+1.0/3.0)+10.0/63.0)  *2.0*u0*cmath.pow(cmath.cos(etav[k]),1.5) +(1.6*cmath.pow(cmath.cos(phi),3) *(cmath.pow(cmath.sin(phi),2)+2.0/3.0)-pii/4.0)*r_earth*omega_e)/(1.0+0.61*qv_2d[nlat*k + i])
+        temperature_1d[k] = teta[k]+.75*eta[k]*constants.pii*u0/constants.rgas*cmath.sin(etav[k])  *cmath.sqrt(cmath.cos(etav[k]))* ((-2.*cmath.pow(cmath.sin(phi),6)  *(cmath.pow(cmath.cos(phi),2)+1.0/3.0)+10.0/63.0)  *2.0*u0*cmath.pow(cmath.cos(etav[k]),1.5) +(1.6*cmath.pow(cmath.cos(phi),3) *(cmath.pow(cmath.sin(phi),2)+2.0/3.0)-constants.pii/4.0)*r_earth*omega_e)/(1.0+0.61*qv_2d[nlat*k + i])
 
         ztemp   = .5*(zgrid_2d[k * nlat + i]+zgrid_2d[(k+1) * nlat + i])
         ptemp   = ppb_2d[k * nlat + i] + pp_2d[k * nlat + i]
@@ -337,15 +332,15 @@ where reads writes(vr, er, cr, vertr) do
 
       for itrp = 0,25 do
         for k=0,nz1 do
-          rr_2d[k * nlat + i]  = (pp_2d[k * nlat + i]/(rgas*zz_2d[k * nlat + i]) - rb_2d[k * nlat + i]*(tt[k]-t0b))/tt[k]
+          rr_2d[k * nlat + i]  = (pp_2d[k * nlat + i]/(constants.rgas*zz_2d[k * nlat + i]) - rb_2d[k * nlat + i]*(tt[k]-t0b))/tt[k]
         end
 
-        ppi[1] = p0-.5*dzw[1]*gravity *(1.25*(rr_2d[1 * nlat + i]+rb_2d[1 * nlat + i])*(1.0+qv_2d[1*nlat + i])  -.25*(rr_2d[2 * nlat + i]+rb_2d[2 * nlat + i])*(1.0+qv_2d[2 * nlat + i]))
+        ppi[1] = p0-.5*dzw[1]*constants.gravity *(1.25*(rr_2d[1 * nlat + i]+rb_2d[1 * nlat + i])*(1.0+qv_2d[1*nlat + i])  -.25*(rr_2d[2 * nlat + i]+rb_2d[2 * nlat + i])*(1.0+qv_2d[2 * nlat + i]))
 
         ppi[1] = ppi[1]-ppb_2d[1 * nlat + i]
         for k=0, nz1-1 do
 
-          ppi[k+1] = ppi[k]-vertr[k+1].dzu*gravity*  ( (rr_2d[k * nlat + i]+(rr_2d[k * nlat + i] +rb_2d[k * nlat + i])*qv_2d[k*nlat + i])*vertr[k+1].fzp  + (rr_2d[(k+1) * nlat + i]+(rr_2d[(k+1) * nlat + i]+rb_2d[(k+1) * nlat + i])*qv_2d[(k+1) * nlat + i])*vertr[k+1].fzm )
+          ppi[k+1] = ppi[k]-vertr[k+1].dzu*constants.gravity*  ( (rr_2d[k * nlat + i]+(rr_2d[k * nlat + i] +rb_2d[k * nlat + i])*qv_2d[k*nlat + i])*vertr[k+1].fzp  + (rr_2d[(k+1) * nlat + i]+(rr_2d[(k+1) * nlat + i]+rb_2d[(k+1) * nlat + i])*qv_2d[(k+1) * nlat + i])*vertr[k+1].fzm )
         end
 
         for k=0, nz1 do
@@ -359,7 +354,7 @@ where reads writes(vr, er, cr, vertr) do
 
     for k = 0, nz1 do
       rho_2d[k * nlat + i] = rr_2d[k * nlat + i]+rb_2d[k * nlat + i]
-      etavs_2d[k * nlat + i] = ((ppb_2d[k * nlat + i]+pp_2d[k * nlat + i])/p0 - 0.252)*pii/2.0
+      etavs_2d[k * nlat + i] = ((ppb_2d[k * nlat + i]+pp_2d[k * nlat + i])/p0 - 0.252)*constants.pii/2.0
       u_2d[k * nlat + i] = u0*(cmath.pow(cmath.sin(2.*lat_2d[i]),2)) * (cmath.pow(cmath.cos(etavs_2d[k * nlat + i]),1.5))
     end
 
@@ -400,9 +395,9 @@ where reads writes(vr, er, cr, vertr) do
   for i=0, nCells do
     for k=0,nz1 do
       ztemp    = .5*(cr[{i, k+1}].zgrid+cr[{k,i}].zgrid)
-      cr[{i, k}].pressure_base = p0*cmath.exp(-gravity*ztemp/(rgas*t0b))
-      cr[{i, k}].pressure_p = cmath.pow((cr[{i, k}].pressure_base/p0),(rgas/cp))
-      cr[{i, k}].rho_base = cr[{i, k}].pressure_base/(rgas*t0b*cr[{i, k}].zz)
+      cr[{i, k}].pressure_base = p0*cmath.exp(-constants.gravity*ztemp/(constants.rgas*t0b))
+      cr[{i, k}].pressure_p = cmath.pow((cr[{i, k}].pressure_base/p0),(constants.rgas/constants.cp))
+      cr[{i, k}].rho_base = cr[{i, k}].pressure_base/(constants.rgas*t0b*cr[{i, k}].zz)
       cr[{i, k}].theta_base = t0b/cr[{i, k}].pressure_p
       cr[{i, k}].rtheta_base = cr[{i, k}].rho_base*cr[{i, k}].theta_base
       cr[{i, k}].exner = cr[{i, k}].pressure_p
@@ -416,16 +411,16 @@ where reads writes(vr, er, cr, vertr) do
 
       for k=0, nz1 do
         eta[k] = (cr[{i, k}].pressure_base+cr[{i, k}].pressure_p)/p0
-        etav[k] = (eta[k]-.252)*pii/2.
+        etav[k] = (eta[k]-.252)*constants.pii/2.
         if(eta[k] >= znut)  then
-          teta[k] = t0*cmath.pow(eta[k],(rgas*dtdz/gravity))
+          teta[k] = t0*cmath.pow(eta[k],(constants.rgas*dtdz/constants.gravity))
         else
-          teta[k] = t0*cmath.pow(eta[k],(rgas*dtdz/gravity)) + delta_t*cmath.pow((znut-eta[k]),5)
+          teta[k] = t0*cmath.pow(eta[k],(constants.rgas*dtdz/constants.gravity)) + delta_t*cmath.pow((znut-eta[k]),5)
         end
       end
       phi = cr[{i, 0}].lat
       for k=0,nz1 do
-        temperature_1d[k] = teta[k]+.75*eta[k]*pii*u0/rgas*cmath.sin(etav[k])  *cmath.sqrt(cmath.cos(etav[k]))* ((-2.0*cmath.pow(cmath.sin(phi),6)  *(cmath.pow(cmath.cos(phi),2)+1.0/3.0)+10.0/63.0) *2.*u0*cmath.pow(cmath.cos(etav[k]),1.5)   +(1.6*cmath.pow(cmath.cos(phi),3)   *(cmath.pow(cmath.sin(phi),2)+2.0/3.0)-pii/4.0)*r_earth*omega_e)/(1.+0.61*cr[{i, k}].qv)
+        temperature_1d[k] = teta[k]+.75*eta[k]*constants.pii*u0/constants.rgas*cmath.sin(etav[k])  *cmath.sqrt(cmath.cos(etav[k]))* ((-2.0*cmath.pow(cmath.sin(phi),6)  *(cmath.pow(cmath.cos(phi),2)+1.0/3.0)+10.0/63.0) *2.*u0*cmath.pow(cmath.cos(etav[k]),1.5)   +(1.6*cmath.pow(cmath.cos(phi),3)   *(cmath.pow(cmath.sin(phi),2)+2.0/3.0)-constants.pii/4.0)*r_earth*omega_e)/(1.+0.61*cr[{i, k}].qv)
 
         ztemp   = .5*(cr[{k,i}].zgrid+cr[{i, k+1}].zgrid)
         ptemp   = cr[{i, k}].pressure_base + cr[{i, k}].pressure_p
@@ -466,16 +461,16 @@ where reads writes(vr, er, cr, vertr) do
 
       for itrp = 0,25 do
         for k=0,nz1 do
-          cr[{i,k}].rho_p  = (cr[{i, k}].pressure_p/(rgas*cr[{i, k}].zz) - cr[{i, k}].rho_base*(tt[k]-t0b))/tt[k]
+          cr[{i,k}].rho_p  = (cr[{i, k}].pressure_p/(constants.rgas*cr[{i, k}].zz) - cr[{i, k}].rho_base*(tt[k]-t0b))/tt[k]
         end
 
-        ppi[1] = p0-.5*dzw[1]*gravity *(1.25*(cr[{i, 1}].rho_p+cr[{i, 1}].rho_base)*(1.+cr[{i, 0}].qv ) -.25*(cr[{i, 2}].rho_p+cr[{i, 2}].rho_base)*(1.+cr[{i, 1}].qv))
+        ppi[1] = p0-.5*dzw[1]*constants.gravity *(1.25*(cr[{i, 1}].rho_p+cr[{i, 1}].rho_base)*(1.+cr[{i, 0}].qv ) -.25*(cr[{i, 2}].rho_p+cr[{i, 2}].rho_base)*(1.+cr[{i, 1}].qv))
 
         ppi[1] = ppi[1]-cr[{i, 1}].pressure_base
         for k=0,nz1-1 do
 
 
-           ppi[k+1] = ppi[k]-vertr[k+1].dzu*gravity* ( (cr[{i,k}].rho_p+(cr[{i,k}].rho_p+cr[{i, k}].rho_base)*cr[{i, k}].qv)*vertr[k+1].fzp   + (cr[{i, k+1}].rho_p+(cr[{i, k+1}].rho_p+cr[{i, k+1}].rho_base)*cr[{i, k+1}].qv)*vertr[k+1].fzm)
+           ppi[k+1] = ppi[k]-vertr[k+1].dzu*constants.gravity* ( (cr[{i,k}].rho_p+(cr[{i,k}].rho_p+cr[{i, k}].rho_base)*cr[{i, k}].qv)*vertr[k+1].fzp   + (cr[{i, k+1}].rho_p+(cr[{i, k+1}].rho_p+cr[{i, k+1}].rho_base)*cr[{i, k+1}].qv)*vertr[k+1].fzm)
 
         end
 
@@ -492,20 +487,20 @@ where reads writes(vr, er, cr, vertr) do
 
 
     for k=0,nz1 do
-      cr[{i, k}].exner = cmath.pow(((cr[{i, k}].pressure_base+cr[{i, k}].pressure_p)/p0),(rgas/cp))
+      cr[{i, k}].exner = cmath.pow(((cr[{i, k}].pressure_base+cr[{i, k}].pressure_p)/p0),(constants.rgas/constants.cp))
       cr[{i, k}].theta_m = tt[k]/cr[{i, k}].exner
       cr[{i, k}].rtheta_p = cr[{i, k}].theta_m * cr[{i,k}].rho_p+cr[{i, k}].rho_base*(cr[{i, k}].theta_m-cr[{i, k}].theta_base)
       cr[{i, k}].rho_zz = cr[{i, k}].rho_base + cr[{i,k}].rho_p
     end
 
     --calculation of surface pressure:
-    cr[{i, 0}].surface_pressure = 0.5*dzw[1]*gravity * (1.25*(cr[{i, 1}].rho_p + cr[{i, 1}].rho_base) * (1.0 + cr[{i, 0}].qv) -  0.25*(cr[{i, 2}].rho_p + cr[{i, 2}].rho_base) * (1.0 + cr[{i, 1}].qv))
+    cr[{i, 0}].surface_pressure = 0.5*dzw[1]*constants.gravity * (1.25*(cr[{i, 1}].rho_p + cr[{i, 1}].rho_base) * (1.0 + cr[{i, 0}].qv) -  0.25*(cr[{i, 2}].rho_p + cr[{i, 2}].rho_base) * (1.0 + cr[{i, 1}].qv))
     cr[{i, 0}].surface_pressure = cr[{i, 0}].surface_pressure + cr[{i, 1}].pressure_p + cr[{i, 1}].pressure_base
 
   end   -- end loop over cells
 
-  var lat_pert = latitude_pert*pii/180.0
-  var lon_pert = longitude_pert*pii/180.0
+  var lat_pert = latitude_pert*constants.pii/180.0
+  var lon_pert = longitude_pert*constants.pii/180.0
 
 
 
@@ -549,7 +544,7 @@ where reads writes(vr, er, cr, vertr) do
 --     else
 
 --       do k=1,nVertLevels
---         etavs = (0.5*(pressure_base(k,iCell1)+pressure_base(k,iCell2)+pp(k,iCell1)+pp(k,iCell2))/p0 - 0.252)*pii/2.
+--         etavs = (0.5*(pressure_base(k,iCell1)+pressure_base(k,iCell2)+pp(k,iCell1)+pp(k,iCell2))/p0 - 0.252)*constants.pii/2.
 --         fluxk = u0*flux*(cmath.cos(etavs)**1.5)
 --         u(k,iEdge) = fluxk + u_pert
 --       end do
@@ -558,7 +553,7 @@ where reads writes(vr, er, cr, vertr) do
 
 
      for k=0, nVertLevels do
-       etavs = (0.5*(cr[{iCell1, k}].pressure_base+cr[{iCell2, k}].pressure_base+cr[{iCell1, k}].pressure_p+cr[{iCell2, k}].pressure_p)/p0 - 0.252)*pii/2.0
+       etavs = (0.5*(cr[{iCell1, k}].pressure_base+cr[{iCell2, k}].pressure_base+cr[{iCell1, k}].pressure_p+cr[{iCell2, k}].pressure_p)/p0 - 0.252)*constants.pii/2.0
        var fluxk = u0*flux*(cmath.pow(cmath.cos(etavs),1.5))
        er[{iEdge, k}].u = fluxk + u_pert
      end
@@ -709,7 +704,7 @@ where reads writes(vr, er, cr, vertr) do
 --  for i=0,10 do
 --    psurf = (cf1*(pressure_base(1,i)+pp(1,i)) + cf2*(pressure_base(2,i)+pp(2,i)) + cf3*(pressure_base(3,i)+pp(3,i)))/100.
 --
---        psurf = (pressure_base(1,i)+pp(1,i)) + .5*dzw[1]*gravity        &
+--        psurf = (pressure_base(1,i)+pp(1,i)) + .5*dzw[1]*constants.gravity        &
 --                      *(1.25*(rr(1,i)+rb(1,i))*(1.+scalars(index_qv,1,i))   &
 --                       -.25*(rr(2,i)+rb(2,i))*(1.+scalars(index_qv,2,i)))
 --


### PR DESCRIPTION
Previously, some functions had passed in constants as parameters instead of getting them from constants.rg. This streamlines the function parameters by always using the constants file instead of passing them from function to function.